### PR TITLE
chore: Update README.md with more info for the smithy-build.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ To add a minimal `typescript-client-codegen` plugin, add the following to `smith
     // Add the Smithy TypeScript code generator dependency
     "maven": {
         "dependencies": [
-            "software.amazon.smithy.typescript:smithy-typescript-codegen:0.19.0"
+            "software.amazon.smithy.typescript:smithy-typescript-codegen:0.19.0",
+            "software.amazon.smithy:smithy-aws-traits:1.41.1"
         ]
     },
     "plugins": {
         // Add the Smithy TypeScript client plugin
         "typescript-client-codegen": {
             // Minimal configuration: add package name and version
-            "package": {
-                "package": "@smithy/typescript-example-client",
-                "packageVersion": "0.0.1"
-            }
+            "package": "@smithy/typescript-example-client",
+            "packageVersion": "0.0.1",
+            "protocol": "aws.protocols#restJson1"
         }
     }
 }


### PR DESCRIPTION
Updated the README file, the `smithy-build.json` section
* package.package yielded errors
* the dependencies were incomplete

I made the changes for the sake of being explicit, it is easier to replace in place than to find missing tokens.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
